### PR TITLE
Issue 1 change observable prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,13 @@ Assuming you're already using `@maybe-remote/core` as shown above, adding RxJS o
 npm i -S @maybe-remote/rxjs rxjs
 ```
 
-**Step 2**: Write a function that returns an RxJS observable. The method should be prefixed with `when`. For example `whenDataArrives` or the like.
+**Step 2**: Write a function that returns an RxJS observable. The method should be prefixed with `stream`. For example `streamMyData` or the like.
 
 ```ts
 // my-service.ts
 import { interval } from 'rxjs';
 
-export function whenIntervalFires(delay: number) {
+export function streamInterval(delay: number) {
   return interval(delay);
 }
 ```
@@ -137,5 +137,5 @@ const client = createPostMessageClient<ServiceDefinition>({
 });
 
 // Logs a number once a second for 5 numbers
-client.whenInterval(1000).pipe(take(5)).subscribe(console.log);
+client.streamInterval(1000).pipe(take(5)).subscribe(console.log);
 ```

--- a/packages/core/src/lib/default-plugins.ts
+++ b/packages/core/src/lib/default-plugins.ts
@@ -11,6 +11,6 @@ export const defaultServicePlugins: ServicePlugin[] = [
 ];
 
 export const defaultClientPlugins: ClientPlugin[] = [
-  asyncIterationClientPlugin,
+  asyncIterationClientPlugin(),
   promiseClientPlugin,
 ];

--- a/packages/demo-app/src/app/app.tsx
+++ b/packages/demo-app/src/app/app.tsx
@@ -113,7 +113,7 @@ export function TestRxJSObservables() {
 
     const valuesToSum = values.split('+').map((v) => parseInt(v.trim()));
 
-    const sums$ = client.whenSummedValuesArePushed(...valuesToSum);
+    const sums$ = client.streamSummedValues(...valuesToSum);
 
     subscriptionRef.current?.unsubscribe();
     setSums([]);

--- a/packages/demo-app/src/app/demo-service.ts
+++ b/packages/demo-app/src/app/demo-service.ts
@@ -12,6 +12,6 @@ export async function* iterateProgressiveSums(...numbers: number[]) {
   }
 }
 
-export function whenSummedValuesArePushed(...numbers: number[]) {
+export function streamSummedValues(...numbers: number[]) {
   return from(numbers).pipe(scan((sum, value) => sum + value, 0));
 }

--- a/packages/rxjs/src/lib/rxjs-plugin.ts
+++ b/packages/rxjs/src/lib/rxjs-plugin.ts
@@ -240,7 +240,7 @@ export function rxjsClientPlugin() {
   return (method: string, connection: ServiceConnection) => {
     scheduleCleanRefs(connection);
 
-    if (method.startsWith('when')) {
+    if (method.startsWith('stream')) {
       return (...params: any[]) => {
         const subscriptionId = crypto.randomUUID();
 


### PR DESCRIPTION
Changse the prefix for functions returning observables from `@maybe-remote/rxjs` to be `"stream"` instead of `"when"`.

Also fixes a bug where the async iteration plugin was registered improperly.